### PR TITLE
Fix ESLint restricted global usage

### DIFF
--- a/src/components/inventory/DeletePlate.js
+++ b/src/components/inventory/DeletePlate.js
@@ -559,7 +559,7 @@ Escribe "ELIMINAR" (en mayúsculas) para confirmar:`;
     }
 
     // Segunda confirmación de seguridad
-    const finalConfirm = confirm(`🚨 ÚLTIMA CONFIRMACIÓN 🚨\n\n¿Proceder con la eliminación DEFINITIVA de la placa ${placa.id_visual}?\n\nNo habrá más advertencias después de esto.`);
+    const finalConfirm = window.confirm(`🚨 ÚLTIMA CONFIRMACIÓN 🚨\n\n¿Proceder con la eliminación DEFINITIVA de la placa ${placa.id_visual}?\n\nNo habrá más advertencias después de esto.`);
     
     if (!finalConfirm) {
       alert('❌ Eliminación cancelada en la confirmación final.');


### PR DESCRIPTION
## Summary
- use `window.confirm` instead of the restricted global `confirm`

## Testing
- `npm run build`
- `npm test -- --watchAll=false` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_688544b3b5c48328b1310c7a04b051af