### PR TITLE
Fix DeletePlate confirmation modal

### DIFF
--- a/src/components/inventory/DeletePlate.js
+++ b/src/components/inventory/DeletePlate.js
@@ -559,7 +559,7 @@ Escribe "ELIMINAR" (en mayúsculas) para confirmar:`;
     }
 
     // Segunda confirmación de seguridad
-    const finalConfirm = confirm(`🚨 ÚLTIMA CONFIRMACIÓN 🚨\n\n¿Proceder con la eliminación DEFINITIVA de la placa ${placa.id_visual}?\n\nNo habrá más advertencias después de esto.`);
+    const finalConfirm = window.confirm(`🚨 ÚLTIMA CONFIRMACIÓN 🚨\n\n¿Proceder con la eliminación DEFINITIVA de la placa ${placa.id_visual}?\n\nNo habrá más advertencias después de esto.`);
     
     if (!finalConfirm) {
       alert('❌ Eliminación cancelada en la confirmación final.');


### PR DESCRIPTION
## Summary
- fix use of deprecated `confirm()` causing build errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688552851e6883289395829a11b62fe0