### PR TITLE
Fix restricted global confirm usage

### DIFF
--- a/src/components/inventory/DeletePlate.js
+++ b/src/components/inventory/DeletePlate.js
@@ -559,7 +559,7 @@ Escribe "ELIMINAR" (en mayúsculas) para confirmar:`;
     }
 
     // Segunda confirmación de seguridad
-    const finalConfirm = confirm(`🚨 ÚLTIMA CONFIRMACIÓN 🚨\n\n¿Proceder con la eliminación DEFINITIVA de la placa ${placa.id_visual}?\n\nNo habrá más advertencias después de esto.`);
+    const finalConfirm = window.confirm(`🚨 ÚLTIMA CONFIRMACIÓN 🚨\n\n¿Proceder con la eliminación DEFINITIVA de la placa ${placa.id_visual}?\n\nNo habrá más advertencias después de esto.`);
     
     if (!finalConfirm) {
       alert('❌ Eliminación cancelada en la confirmación final.');


### PR DESCRIPTION
## Summary
- use `window.confirm` for final deletion confirmation

## Testing
- `npm test --silent -- -w 1`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68855a76199c832894568ae2d49835d5